### PR TITLE
fix for some issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ Getting started
 Install package using pip (prefer virtualenv)::
 
     pip install coinaddress
+    python -m pip install pysha3
 
 And you can start use provided CLI. Read help first::
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,3 +11,5 @@ twine==1.14.0
 Click==7.0
 pytest==4.6.5
 pytest-runner==5.1
+ecdsa
+base58

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     'ecdsa>=0.14.1',
     'base58>=1.0.3',
     'crypto>=1.4.1',
-    'pysha3>=1.0.2',
+    ## 'pysha3>=1.0.2', python -m pip install pysha3 is the ONLY way that pysha3 should be installed. not this current way.
 ]
 
 setup_requirements = ['pytest-runner', ]


### PR DESCRIPTION
**Added** into requirements_dev.txt:
- `ecdsa`
- `base58` 

**Added** 
`python -m pip install pysha3` in the instructions for the README. 

The reason for this is: 

You are calling a function that is not present in `hashlib` library. You want to call function `sha3_228` from module `sha3`, that is shipped with package `pysha3`. In fact, `sha3_228` does not exist, it is `sha3_224` that exists.

Simply replace `hashlib.sha3_228` with `sha3.sha3_224`.

And make sure you have installed `pysha3`, with command

**`python -m pip install pysha3`**

Here is an example

```import sha3
data='maydata'
s=sha3.sha3_224(data.encode('utf-8')).hexdigest()
print(s)
20faf4bf0bbb9ca9b3a47282afe713ba53c9e243bc8bdf1d670671cb```